### PR TITLE
Add Mpesa and Mastercard payment SDK configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'com.google.gms.google-services'
     id 'com.google.firebase.crashlytics'
 }
+def enablePaytmSdk = project.hasProperty('enablePaytmSdk') ? project.property('enablePaytmSdk').toBoolean() : true
+
 android {
     compileSdk 34
     defaultConfig {
@@ -14,6 +16,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         multiDexEnabled true
+
+        buildConfigField "boolean", "ENABLE_PAYTM_SDK", enablePaytmSdk.toString()
     }
     buildTypes {
         release {
@@ -85,8 +89,17 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    // PayTm All-In-One SDK
-    implementation 'com.paytm.appinvokesdk:appinvokesdk:1.6.17'
+    // Safaricom M-Pesa SDK -------------------------------------------------------
+    implementation 'com.github.safaricom:mpesa-android-sdk:1.0.9'
+
+    // Mastercard Payment Gateway SDK --------------------------------------------
+    implementation 'com.mastercard.gateway:gateway-android:1.7.3'
+    implementation 'com.mastercard.gateway:gateway-android-web:1.7.3'
+
+    // PayTm All-In-One SDK (optional legacy support) ----------------------------
+    if (enablePaytmSdk) {
+        implementation 'com.paytm.appinvokesdk:appinvokesdk:1.6.17'
+    }
 
 //    // PayUMoney SDK
 //    implementation 'com.payumoney.sdkui:plug-n-play:1.6.1'
@@ -111,5 +124,6 @@ dependencies {
 repositories {
     google()
     mavenCentral()
+    maven { url 'https://jitpack.io' }
     flatDir { dirs 'libs' }   // 👈 must be here (app level)
 }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,16 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Safaricom M-Pesa SDK
+-keep class com.safaricom.mpesa.** { *; }
+-dontwarn com.safaricom.mpesa.**
+-dontwarn okhttp3.**
+-dontwarn okio.**
+
+# Mastercard Payment Gateway SDK
+-keep class com.mastercard.gateway.** { *; }
+-keep class com.mastercard.api.** { *; }
+-dontwarn com.mastercard.gateway.**
+-dontwarn com.mastercard.api.**
+-dontwarn org.slf4j.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,10 +16,14 @@
     <queries>
         <!-- Specific apps you interact with, eg: -->
         <package android:name="com.ludo.king" />
+        <package android:name="com.android.stk" />
         <!-- Specific intents you query for, eg: for a custom share UI -->
         <intent>
             <action android:name="com.ludo.king" />
             <data android:scheme="com.ludo.king" />
+        </intent>
+        <intent>
+            <action android:name="com.safaricom.mpesa.android.intent.ACTION_STK_PUSH" />
         </intent>
         <intent>
             <action android:name="android.intent.action.SENDTO" />
@@ -272,6 +276,22 @@
 
 
 
+        <activity
+            android:name="com.safaricom.mpesa.stk.push.ui.MpesaPaymentActivity"
+            android:exported="false"
+            android:launchMode="singleTop"
+            android:theme="@style/Theme.AppCompat.Dialog" />
+
+        <service
+            android:name="com.safaricom.mpesa.stk.push.network.MpesaCallbackJobService"
+            android:exported="false"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
+
+        <activity
+            android:name="com.mastercard.gateway.android.webview3ds.VerificationActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Translucent" />
+
         <!-- PayU -->
 <!--        <activity-->
 <!--            android:name="com.payu.custombrowser.PreLollipopPaymentsActivity"-->
@@ -297,3 +317,4 @@
     </application>
 
 </manifest>
+

--- a/app/src/main/java/com/tomtomkenya/africanludo/activity/DepositActivity.java
+++ b/app/src/main/java/com/tomtomkenya/africanludo/activity/DepositActivity.java
@@ -22,6 +22,7 @@ import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.tomtomkenya.africanludo.BuildConfig;
 import com.tomtomkenya.africanludo.MyApplication;
 import com.tomtomkenya.africanludo.R;
 import com.tomtomkenya.africanludo.api.ApiCalling;
@@ -61,7 +62,7 @@ public class DepositActivity extends AppCompatActivity implements PaymentResultL
     private ApiCalling api;
 
     private String amountSt;
-    private String mopSt = "PayTm";
+    private String mopSt = BuildConfig.ENABLE_PAYTM_SDK ? "PayTm" : "RazorPay";
     public String orderIdSt, paymentIdSt, checksumSt, tokenSt;
 
     private static final String TAG = DepositActivity.class.getSimpleName();
@@ -100,7 +101,11 @@ public class DepositActivity extends AppCompatActivity implements PaymentResultL
         signTv.setText(AppConstant.CURRENCY_SIGN);
         alertTv.setText(String.format("Minimum Add Amount is %s%d", AppConstant.CURRENCY_SIGN, AppConstant.MIN_DEPOSIT_LIMIT));
 
-        payTmRb.setOnClickListener(v -> mopSt = "PayTm");
+        if (BuildConfig.ENABLE_PAYTM_SDK) {
+            payTmRb.setOnClickListener(v -> mopSt = "PayTm");
+        } else {
+            payTmRb.setOnClickListener(v -> Toast.makeText(this, R.string.paytm_disabled_message, Toast.LENGTH_SHORT).show());
+        }
 
         //payuRb.setOnClickListener(v -> mopSt = "PayUMoney");
 
@@ -109,10 +114,10 @@ public class DepositActivity extends AppCompatActivity implements PaymentResultL
         switch (AppConstant.MODE_OF_PAYMENT) {
             case 1:
                 radioGroup.setVisibility(View.GONE);
-                payTmRb.setVisibility(View.VISIBLE);
+                payTmRb.setVisibility(BuildConfig.ENABLE_PAYTM_SDK ? View.VISIBLE : View.GONE);
                 payuRb.setVisibility(View.GONE);
                 flutterWaveRb.setVisibility(View.GONE);
-                mopSt = "PayTm";
+                mopSt = BuildConfig.ENABLE_PAYTM_SDK ? "PayTm" : "RazorPay";
                 break;
             case 2:
                 radioGroup.setVisibility(View.GONE);
@@ -130,10 +135,10 @@ public class DepositActivity extends AppCompatActivity implements PaymentResultL
                 break;
             default:
                 radioGroup.setVisibility(View.VISIBLE);
-                payTmRb.setVisibility(View.VISIBLE);
+                payTmRb.setVisibility(BuildConfig.ENABLE_PAYTM_SDK ? View.VISIBLE : View.GONE);
                 payuRb.setVisibility(View.VISIBLE);
                 flutterWaveRb.setVisibility(View.VISIBLE);
-                mopSt = "PayTm";
+                mopSt = BuildConfig.ENABLE_PAYTM_SDK ? "PayTm" : "RazorPay";
                 break;
         }
 
@@ -174,7 +179,12 @@ public class DepositActivity extends AppCompatActivity implements PaymentResultL
                         submitBt.setEnabled(false);
                         switch (mopSt) {
                             case "PayTm":
-                                getPayTmToken();
+                                if (BuildConfig.ENABLE_PAYTM_SDK) {
+                                    getPayTmToken();
+                                } else {
+                                    submitBt.setEnabled(true);
+                                    Toast.makeText(DepositActivity.this, R.string.paytm_disabled_message, Toast.LENGTH_SHORT).show();
+                                }
                                 break;
                             //case "PayUMoney":
                             //    startPayUMoney();

--- a/app/src/main/java/com/tomtomkenya/africanludo/activity/WithdrawActivity.java
+++ b/app/src/main/java/com/tomtomkenya/africanludo/activity/WithdrawActivity.java
@@ -18,6 +18,7 @@ import android.widget.Button;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
+import com.tomtomkenya.africanludo.BuildConfig;
 import com.tomtomkenya.africanludo.MyApplication;
 import com.tomtomkenya.africanludo.R;
 import com.tomtomkenya.africanludo.api.ApiCalling;
@@ -44,7 +45,7 @@ public class WithdrawActivity extends AppCompatActivity {
     private String nameSt;
     private String numberSt;
     private String amountSt;
-    private String mopSt;
+    private String mopSt = BuildConfig.ENABLE_PAYTM_SDK ? "PayTm" : "GooglePay";
     public double deposit = 0, winning = 0, bonus = 0, total = 0;
 
     @SuppressLint({"DefaultLocale", "SetTextI18n"})
@@ -80,11 +81,20 @@ public class WithdrawActivity extends AppCompatActivity {
         signTv.setText(AppConstant.CURRENCY_SIGN);
         alertTv.setText(String.format("Minimum Redeem Amount is %s%d", AppConstant.CURRENCY_SIGN, AppConstant.MIN_WITHDRAW_LIMIT));
 
-        payTmRb.setOnClickListener(v -> {
-            nameEt.setHint("Enter Account Holder Name");
-            numberEt.setHint("Enter PayTm Number");
-            mopSt = "PayTm";
-        });
+        if (BuildConfig.ENABLE_PAYTM_SDK) {
+            payTmRb.setOnClickListener(v -> {
+                nameEt.setHint("Enter Account Holder Name");
+                numberEt.setHint("Enter PayTm Number");
+                mopSt = "PayTm";
+            });
+        } else {
+            payTmRb.setVisibility(View.GONE);
+        }
+
+        if (!BuildConfig.ENABLE_PAYTM_SDK) {
+            googlePayRb.setChecked(true);
+            mopSt = "GooglePay";
+        }
 
         googlePayRb.setOnClickListener(v -> {
             nameEt.setHint("Enter Account Holder Name");
@@ -107,7 +117,7 @@ public class WithdrawActivity extends AppCompatActivity {
                 e.printStackTrace();
             }
 
-            if (payTmRb.isChecked()) {
+            if (BuildConfig.ENABLE_PAYTM_SDK && payTmRb.isChecked()) {
                 mopSt = "PayTm";
                 alertTv.setText("Enter Valid PayTm Number");
             } else if (googlePayRb.isChecked()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,4 +41,5 @@
     <string name="order_placed">Balance Added!!!</string>
     <string name="order_error">Error while payment!!!</string>
     <string name="order_cancel">Cancel payment!!!</string>
+    <string name="paytm_disabled_message">Paytm support is disabled in this build.</string>
 </resources>

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">api.safaricom.co.ke</domain>
+        <domain includeSubdomains="true">sandbox.safaricom.co.ke</domain>
+        <domain includeSubdomains="true">gateway.mastercard.com</domain>
+        <domain includeSubdomains="true">test-gateway.mastercard.com</domain>
+        <domain includeSubdomains="true">api.mastercard.com</domain>
+    </domain-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">https://africanludo.com.podgin.com</domain>
+        <domain includeSubdomains="true">africanludo.com.podgin.com</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
- add the official Safaricom M-Pesa and Mastercard gateway SDK dependencies and repositories while keeping Paytm behind a build flag
- update manifest, network security config, and ProGuard/R8 rules so the new payment callbacks and HTTPS domains work by default
- guard Paytm-specific UI flows so they hide themselves when the SDK is disabled

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6af6e8d38832286b492f00900d924