### PR TITLE
Add Mpesa and Mastercard gateway configuration support

### DIFF
--- a/app/src/main/java/com/tomtomkenya/africanludo/activity/SplashActivity.java
+++ b/app/src/main/java/com/tomtomkenya/africanludo/activity/SplashActivity.java
@@ -12,6 +12,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Handler;
+import android.text.TextUtils;
 import android.util.Base64;
 import android.util.Log;
 import android.view.Window;
@@ -116,83 +117,97 @@ public class SplashActivity extends AppCompatActivity {
             public void onResponse(@NonNull Call<AppModel> call, @NonNull Response<AppModel> response) {
                 if (response.isSuccessful()) {
                     AppModel legalData = response.body();
-                    List<AppModel.Result> res;
                     if (legalData != null) {
-                        res = legalData.getResult();
-                        if (res.get(0).getSuccess() == 1) {
-                            AppConstant.COUNTRY_CODE = res.get(0).getCountry_code();
-                            AppConstant.CURRENCY_CODE = res.get(0).getCurrency_code();
-                            AppConstant.CURRENCY_SIGN = res.get(0).getCurrency_sign();
-                            AppConstant.PAYTM_M_ID = res.get(0).getPaytm_mer_id();
-                            AppConstant.PAYU_M_ID = res.get(0).getPayu_id();
-                            AppConstant.PAYU_M_KEY = res.get(0).getPayu_key();
-                            AppConstant.MIN_JOIN_LIMIT = res.get(0).getMin_entry_fee();
-                            AppConstant.REFERRAL_PERCENTAGE = res.get(0).getRefer_percentage();
-                            AppConstant.MAINTENANCE_MODE = res.get(0).getMaintenance_mode();
-                            AppConstant.MODE_OF_PAYMENT = res.get(0).getMop();
-                            AppConstant.WALLET_MODE = res.get(0).getWallet_mode();
-                            AppConstant.MIN_WITHDRAW_LIMIT = res.get(0).getMin_withdraw();
-                            AppConstant.MAX_WITHDRAW_LIMIT = res.get(0).getMax_withdraw();
-                            AppConstant.MIN_DEPOSIT_LIMIT = res.get(0).getMin_deposit();
-                            AppConstant.MAX_DEPOSIT_LIMIT = res.get(0).getMax_deposit();
-                            AppConstant.GAME_NAME = res.get(0).getGame_name();
-                            AppConstant.PACKAGE_NAME = res.get(0).getPackage_name();
-                            AppConstant.HOW_TO_PLAY = res.get(0).getHow_to_play();
-                            AppConstant.SUPPORT_EMAIL = res.get(0).getCus_support_email();
-                            AppConstant.SUPPORT_MOBILE = res.get(0).getCus_support_mobile();
+                        List<AppModel.Result> res = legalData.getResult();
+                        if (res != null && !res.isEmpty()) {
+                            AppModel.Result result = res.get(0);
+                            if (result.getSuccess() == 1) {
+                                AppConstant.COUNTRY_CODE = result.getCountry_code();
+                                AppConstant.CURRENCY_CODE = result.getCurrency_code();
+                                AppConstant.CURRENCY_SIGN = result.getCurrency_sign();
+                                AppConstant.PAYTM_M_ID = result.getPaytm_mer_id();
+                                AppConstant.PAYU_M_ID = result.getPayu_id();
+                                AppConstant.PAYU_M_KEY = result.getPayu_key();
 
-                            forceUpdate = res.get(0).getForce_update();
-                            whatsNew = res.get(0).getWhats_new();
-                            updateDate = res.get(0).getUpdate_date();
-                            latestVersionName = res.get(0).getLatest_version_name();
-                            latestVersionCode = res.get(0).getLatest_version_code();
-                            updateUrl = res.get(0).getUpdate_url();
+                                String mpesaShortcode = result.getMpesa_shortcode();
+                                String mpesaPasskey = result.getMpesa_passkey();
+                                String mpesaCallbackUrl = result.getMpesa_callback_url();
+                                String mastercardMerchantId = result.getMastercard_merchant_id();
+                                String mastercardMerchantKey = result.getMastercard_merchant_key();
 
-                            try {
-                                if (BuildConfig.VERSION_CODE < Integer.parseInt(latestVersionCode)) {
-                                    if (forceUpdate.equals("1")) {
-                                        Intent intent = new Intent(SplashActivity.this, UpdateAppActivity.class);
-                                        intent.putExtra("forceUpdate", forceUpdate);
-                                        intent.putExtra("whatsNew", whatsNew);
-                                        intent.putExtra("updateDate", updateDate);
-                                        intent.putExtra("latestVersionName", latestVersionName);
-                                        intent.putExtra("updateURL", updateUrl);
-                                        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-                                        startActivity(intent);
-                                    } else if (forceUpdate.equals("0")) {
-                                        Intent intent = new Intent(SplashActivity.this, UpdateAppActivity.class);
-                                        intent.putExtra("forceUpdate", forceUpdate);
-                                        intent.putExtra("whatsNew", whatsNew);
-                                        intent.putExtra("updateDate", updateDate);
-                                        intent.putExtra("latestVersionName", latestVersionName);
-                                        intent.putExtra("updateURL", updateUrl);
-                                        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
-                                        startActivity(intent);
-                                    }
-                                }
-                                else if (AppConstant.MAINTENANCE_MODE == 0) {
-                                    new Handler().postDelayed(() -> {
-                                        if (Preferences.getInstance(SplashActivity.this).getString(Preferences.KEY_IS_AUTO_LOGIN).equals("1")) {
-                                            Intent intent = new Intent(SplashActivity.this, MainActivity.class);
-                                            intent.putExtra("finish", true);
+                                AppConstant.MPESA_SHORTCODE = TextUtils.isEmpty(mpesaShortcode) ? null : mpesaShortcode;
+                                AppConstant.MPESA_PASSKEY = TextUtils.isEmpty(mpesaPasskey) ? null : mpesaPasskey;
+                                AppConstant.MPESA_CALLBACK_URL = TextUtils.isEmpty(mpesaCallbackUrl) ? null : mpesaCallbackUrl;
+                                AppConstant.MASTERCARD_MERCHANT_ID = TextUtils.isEmpty(mastercardMerchantId) ? null : mastercardMerchantId;
+                                AppConstant.MASTERCARD_MERCHANT_KEY = TextUtils.isEmpty(mastercardMerchantKey) ? null : mastercardMerchantKey;
+
+                                AppConstant.MIN_JOIN_LIMIT = result.getMin_entry_fee();
+                                AppConstant.REFERRAL_PERCENTAGE = result.getRefer_percentage();
+                                AppConstant.MAINTENANCE_MODE = result.getMaintenance_mode();
+                                AppConstant.MODE_OF_PAYMENT = result.getMop();
+                                AppConstant.WALLET_MODE = result.getWallet_mode();
+                                AppConstant.MIN_WITHDRAW_LIMIT = result.getMin_withdraw();
+                                AppConstant.MAX_WITHDRAW_LIMIT = result.getMax_withdraw();
+                                AppConstant.MIN_DEPOSIT_LIMIT = result.getMin_deposit();
+                                AppConstant.MAX_DEPOSIT_LIMIT = result.getMax_deposit();
+                                AppConstant.GAME_NAME = result.getGame_name();
+                                AppConstant.PACKAGE_NAME = result.getPackage_name();
+                                AppConstant.HOW_TO_PLAY = result.getHow_to_play();
+                                AppConstant.SUPPORT_EMAIL = result.getCus_support_email();
+                                AppConstant.SUPPORT_MOBILE = result.getCus_support_mobile();
+
+                                forceUpdate = result.getForce_update();
+                                whatsNew = result.getWhats_new();
+                                updateDate = result.getUpdate_date();
+                                latestVersionName = result.getLatest_version_name();
+                                latestVersionCode = result.getLatest_version_code();
+                                updateUrl = result.getUpdate_url();
+
+                                try {
+                                    if (BuildConfig.VERSION_CODE < Integer.parseInt(latestVersionCode)) {
+                                        if (forceUpdate.equals("1")) {
+                                            Intent intent = new Intent(SplashActivity.this, UpdateAppActivity.class);
+                                            intent.putExtra("forceUpdate", forceUpdate);
+                                            intent.putExtra("whatsNew", whatsNew);
+                                            intent.putExtra("updateDate", updateDate);
+                                            intent.putExtra("latestVersionName", latestVersionName);
+                                            intent.putExtra("updateURL", updateUrl);
                                             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
                                             startActivity(intent);
-                                        } else {
-                                            Intent intent = new Intent(SplashActivity.this, LoginActivity.class);
-                                            intent.putExtra("finish", true);
+                                        } else if (forceUpdate.equals("0")) {
+                                            Intent intent = new Intent(SplashActivity.this, UpdateAppActivity.class);
+                                            intent.putExtra("forceUpdate", forceUpdate);
+                                            intent.putExtra("whatsNew", whatsNew);
+                                            intent.putExtra("updateDate", updateDate);
+                                            intent.putExtra("latestVersionName", latestVersionName);
+                                            intent.putExtra("updateURL", updateUrl);
                                             intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
                                             startActivity(intent);
                                         }
-                                        finish();
-                                    },1000);
+                                    }
+                                    else if (AppConstant.MAINTENANCE_MODE == 0) {
+                                        new Handler().postDelayed(() -> {
+                                            if (Preferences.getInstance(SplashActivity.this).getString(Preferences.KEY_IS_AUTO_LOGIN).equals("1")) {
+                                                Intent intent = new Intent(SplashActivity.this, MainActivity.class);
+                                                intent.putExtra("finish", true);
+                                                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+                                                startActivity(intent);
+                                            } else {
+                                                Intent intent = new Intent(SplashActivity.this, LoginActivity.class);
+                                                intent.putExtra("finish", true);
+                                                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+                                                startActivity(intent);
+                                            }
+                                            finish();
+                                        },1000);
+                                    }
+                                    else {
+                                        statusTv.setText("App is under maintenance, please try again later.");
+                                    }
                                 }
-                                else {
-                                    statusTv.setText("App is under maintenance, please try again later.");
+                                catch (Exception e) {
+                                    e.printStackTrace();
                                 }
-                            }
-                            catch (Exception e) {
-                                e.printStackTrace();
-                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/tomtomkenya/africanludo/helper/AppConstant.java
+++ b/app/src/main/java/com/tomtomkenya/africanludo/helper/AppConstant.java
@@ -23,6 +23,15 @@ public class AppConstant {
     public static String PAYU_M_ID = "XXXXXXXXXXXX";
     public static String PAYU_M_KEY = "XXXXXXXXXXX";
 
+    // Put your Mpesa production shortcode, passkey and callback URL
+    public static String MPESA_SHORTCODE = null;
+    public static String MPESA_PASSKEY = null;
+    public static String MPESA_CALLBACK_URL = null;
+
+    // Put your Mastercard production merchant id & key
+    public static String MASTERCARD_MERCHANT_ID = null;
+    public static String MASTERCARD_MERCHANT_KEY = null;
+
     // Set default country code, currency code and sign
     public static String COUNTRY_CODE = "+254";
     public static String CURRENCY_CODE = "USD";
@@ -31,7 +40,13 @@ public class AppConstant {
     // Set default app configuration
     public static int MAINTENANCE_MODE = 0;     // (0 for Off, 1 for On)
     public static int WALLET_MODE =  0;         // (0 for Enable, 1 for Disable)
-    public static int MODE_OF_PAYMENT = 0;      // (0 for PayTm, 1 for PayU, 2 for RazorPay)
+    public static final int PAYMENT_GATEWAY_PAYTM = 0;
+    public static final int PAYMENT_GATEWAY_PAYU = 1;
+    public static final int PAYMENT_GATEWAY_RAZORPAY = 2;
+    public static final int PAYMENT_GATEWAY_MPESA = 3;
+    public static final int PAYMENT_GATEWAY_MASTERCARD = 4;
+
+    public static int MODE_OF_PAYMENT = PAYMENT_GATEWAY_PAYTM;      // (0 for PayTm, 1 for PayU, 2 for RazorPay, 3 for Mpesa, 4 for Mastercard)
 
     // Set Refer Program
     public static int MIN_JOIN_LIMIT = 100;     // (In Amount)

--- a/app/src/main/java/com/tomtomkenya/africanludo/model/AppModel.java
+++ b/app/src/main/java/com/tomtomkenya/africanludo/model/AppModel.java
@@ -43,6 +43,21 @@ public class AppModel {
         @SerializedName("payu_key")
         private String payu_key;
 
+        @SerializedName("mpesa_shortcode")
+        private String mpesa_shortcode;
+
+        @SerializedName("mpesa_passkey")
+        private String mpesa_passkey;
+
+        @SerializedName("mpesa_callback_url")
+        private String mpesa_callback_url;
+
+        @SerializedName("mastercard_merchant_id")
+        private String mastercard_merchant_id;
+
+        @SerializedName("mastercard_merchant_key")
+        private String mastercard_merchant_key;
+
         @SerializedName("flutter_pub_key")
         private String flutter_pub_key;
 
@@ -181,6 +196,46 @@ public class AppModel {
 
         public void setPayu_key(String payu_key) {
             this.payu_key = payu_key;
+        }
+
+        public String getMpesa_shortcode() {
+            return mpesa_shortcode;
+        }
+
+        public void setMpesa_shortcode(String mpesa_shortcode) {
+            this.mpesa_shortcode = mpesa_shortcode;
+        }
+
+        public String getMpesa_passkey() {
+            return mpesa_passkey;
+        }
+
+        public void setMpesa_passkey(String mpesa_passkey) {
+            this.mpesa_passkey = mpesa_passkey;
+        }
+
+        public String getMpesa_callback_url() {
+            return mpesa_callback_url;
+        }
+
+        public void setMpesa_callback_url(String mpesa_callback_url) {
+            this.mpesa_callback_url = mpesa_callback_url;
+        }
+
+        public String getMastercard_merchant_id() {
+            return mastercard_merchant_id;
+        }
+
+        public void setMastercard_merchant_id(String mastercard_merchant_id) {
+            this.mastercard_merchant_id = mastercard_merchant_id;
+        }
+
+        public String getMastercard_merchant_key() {
+            return mastercard_merchant_key;
+        }
+
+        public void setMastercard_merchant_key(String mastercard_merchant_key) {
+            this.mastercard_merchant_key = mastercard_merchant_key;
         }
 
         public String getFlutter_pub_key() {


### PR DESCRIPTION
## Summary
- add Mpesa and Mastercard credential fields to the app model and constants so backend values deserialize correctly
- expose enum-like payment gateway identifiers and update splash initialization logic with null/empty checks
- populate new gateway values during splash configuration while protecting against missing backend data

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6af81bc0083228c5ec031dc57cc38